### PR TITLE
Level generation

### DIFF
--- a/src/models/GameBoard.ts
+++ b/src/models/GameBoard.ts
@@ -5,6 +5,7 @@ class GameBoard extends Phaser.GameObjects.Container {
   cellHeight: number;
   boardWidth: number;
   boardHeight: number;
+  gameOver: boolean = false;
 
   constructor(
     scene: Phaser.Scene,
@@ -221,6 +222,9 @@ class GameBoard extends Phaser.GameObjects.Container {
       color: "#ff0000",
     });
     this.removeInteractive();
+    this.gameOver = true;
+
+    this.scene.events.emit("gameOver");
   }
 }
 

--- a/src/models/Level.ts
+++ b/src/models/Level.ts
@@ -36,7 +36,7 @@ class Level {
   }
 
   startLevel(startX: number, startY: number) {
-    this.board.revealAdjacentCells(19, 10);
+    this.board.revealAdjacentCells(startX, startY);
   }
 }
 

--- a/src/models/Level.ts
+++ b/src/models/Level.ts
@@ -29,7 +29,6 @@ class Level {
       startX,
       startY
     );
-    // this.board.revealAdjacentCells(startX, startY);
     this.playerPosition = [0, 0];
     this.timePlayed = 0;
     this.points = 0;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -52,8 +52,6 @@ class GameScene extends Phaser.Scene {
     this.add.existing(this.level.board);
     this.level.startLevel(boardWidth - 1, Math.floor(boardWidth / 2));
 
-    //Not a clue why this will work here, but when called in generateBoard() it doesn't work
-
     // center
     const centerX = this.cameras.main.width / 2;
     //const centerY = this.cameras.main.height / 2;


### PR DESCRIPTION
This pull request includes several changes to the `GameBoard`, `Level`, and `GameScene` classes to improve game functionality and handling of the game-over state. The most important changes include adding a game-over state to `GameBoard` and `GameScene`, modifying the `startLevel` method in `Level`, and enhancing the `create` method in `GameScene` to handle game-over events.

Enhancements to game-over state:

* [`src/models/GameBoard.ts`](diffhunk://#diff-12e0d6c7cc85eef42832db5e344101a91bb0bbc4dc34064714a7f43e4c2606e0R8): Added `gameOver` property to `GameBoard` and set it to `true` when the game ends. Emitted a "gameOver" event when the game ends. [[1]](diffhunk://#diff-12e0d6c7cc85eef42832db5e344101a91bb0bbc4dc34064714a7f43e4c2606e0R8) [[2]](diffhunk://#diff-12e0d6c7cc85eef42832db5e344101a91bb0bbc4dc34064714a7f43e4c2606e0R225-R227)

* [`src/scenes/GameScene.ts`](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL2-R7): Added `gameOver` property to `GameScene` and implemented a listener for the "gameOver" event to display a game-over message and restart the game when "R" is pressed. [[1]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL2-R7) [[2]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeR35-R90)

Modifications to level initialization:

* [`src/models/Level.ts`](diffhunk://#diff-6d631994de452c73e0ee88a41113602dc5c22cb1deef1b09bb5f94f9ce830b12L32-R39): Updated the `startLevel` method to use the `startX` and `startY` parameters instead of hardcoded values for revealing adjacent cells.

Code organization and cleanup:

* [`src/scenes/GameScene.ts`](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeR23-R24): Added a `keydownListener` to handle keypress events and organized the `create` method to reset the level and initialize game objects properly. [[1]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeR23-R24) [[2]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL55-R124) [[3]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL77-R133) [[4]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL86-R157) [[5]](diffhunk://#diff-937a693b3fb2e6bdc1caf7f1f1a3390c6209a2c91569c38bf925f687dda2d8eeL112-R169)